### PR TITLE
Refactor LifeView dispose method to reset checkboxes.

### DIFF
--- a/life-view.js
+++ b/life-view.js
@@ -114,6 +114,7 @@ class LifeView {
         this.grid.removeEventListener("click", this.disableClick)
 
         this.grid.innerHTML = "";
+        this.checkboxes = [];
     }
 
 


### PR DESCRIPTION
The code changes remove all checkboxes from the grid when the dispose method is called. Found that dangling artifacts would reappear on resize